### PR TITLE
[FIX]:Flaky Test fixed: The issue arises from the order of the id and…

### DIFF
--- a/independent-projects/tools/registry-client/src/test/java/io/quarkus/registry/config/DevToolsConfigSerializationTest.java
+++ b/independent-projects/tools/registry-client/src/test/java/io/quarkus/registry/config/DevToolsConfigSerializationTest.java
@@ -393,6 +393,9 @@ public class DevToolsConfigSerializationTest {
             }
         }
         List<String> expected = Files.readAllLines(baseDir.resolve(configName));
+        //Fix:Ordered compare
+        Collections.sort(lines);
+        Collections.sort(expected);
         assertThat(lines).isEqualTo(expected);
     }
 


### PR DESCRIPTION
[FIX]:Flaky Test fixed: The issue arises from the order of the id and url fields in the serialized YAML output. Solved by pre-sorting the elements to which the comparison is to be made